### PR TITLE
Add recursive merge and recursive distinct merge functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Dot has the following methods:
 - [has()](#has)
 - [isEmpty()](#isEmpty)
 - [merge()](#merge)
+- [mergeRecursive()](#mergeRecursive)
+- [mergeRecursiveDistinct()](#mergeRecursiveDistinct)
 - [pull()](#pull)
 - [push()](#push)
 - [set()](#set)
@@ -260,6 +262,41 @@ $dot->merge('user', $array);
 
 // Equivalent vanilla PHP
 array_merge($originalArray['user'], $array);
+```
+
+<a name="mergeRecursive"></a>
+### mergeRecursive()
+
+Recursively merges a given array or another Dot object:
+```php
+$dot->mergeRecursive($array);
+
+// Equivalent vanilla PHP
+array_merge_recursive($originalArray, $array);
+```
+
+Recursively merges a given array or another Dot object with the given key:
+```php
+$dot->mergeRecursive('user', $array);
+
+// Equivalent vanilla PHP
+array_merge_recursive($originalArray['user'], $array);
+```
+
+<a name="mergeRecursiveDistinct"></a>
+### mergeRecursiveDistinct()
+
+Recursively merges a given array or another Dot object. Duplicate keys overwrite the value in the
+original array (unlike [mergeRecursiveDistinct()](#mergeRecursiveDistinct), where duplicate keys are transformed
+into arrays with multiple values):
+```php
+$dot->mergeRecursiveDistinct($array);
+```
+
+Recursively merges a given array or another Dot object with the given key. Duplicate keys overwrite the value in the
+original array.
+```php
+$dot->mergeRecursiveDistinct('user', $array);
 ```
 
 <a name="pull"></a>

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -261,6 +261,54 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
+     * Recursively merge a given array or a Dot object with the given key
+     * or with the whole Dot object.
+     *
+     * Duplicate key are converted to arrays.
+     *
+     * @param array|string|self $key
+     * @param array             $value
+     */
+    public function mergeRecursive($key, $value = null)
+    {
+        if (is_array($key)) {
+            $this->items = array_merge_recursive($this->items, $key);
+        } elseif (is_string($key)) {
+            $items = (array) $this->get($key);
+            $value = array_merge_recursive($items, $this->getArrayItems($value));
+
+            $this->set($key, $value);
+        } elseif ($key instanceof self) {
+            $this->items = array_merge_recursive($this->items, $key->all());
+        }
+    }
+
+    /**
+     * Recursively merge a given array or a Dot object with the given key
+     * or with the whole Dot object.
+     *
+     * Duplicate key are not converted to arrays but rather overvwrite
+     * the value in the first array with the duplicate value in the second
+     * array.
+     *
+     * @param array|string|self $key
+     * @param array             $value
+     */
+    public function mergeRecursiveDistinct($key, $value = null)
+    {
+        if (is_array($key)) {
+            $this->items = $this->array_merge_recursive_distinct($this->items, $key);
+        } elseif (is_string($key)) {
+            $items = (array) $this->get($key);
+            $value = $this->array_merge_recursive_distinct($items, $this->getArrayItems($value));
+
+            $this->set($key, $value);
+        } elseif ($key instanceof self) {
+            $this->items = $this->array_merge_recursive_distinct($this->items, $key->all());
+        }
+    }
+
+    /**
      * Return the value of a given key and
      * delete the key
      *
@@ -475,5 +523,39 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
     public function jsonSerialize()
     {
         return $this->items;
+    }
+
+    /**
+     * Merges two arrays recursively. In contrast to array_merge_recursive,
+     * duplicate key are not converted to arrays but rather overvwrite the
+     * value in the first array with the duplicate value in the second array.
+     *
+     * array_merge_recursive(array('key' => 'org value'), array('key' => 'new value'));
+     *     => array('key' => array('org value', 'new value'));
+     *
+     * array_merge_recursive_distinct(array('key' => 'org value'), array('key' => 'new value'));
+     *     => array('key' => array('new value'));
+     *
+     * @param array $array1
+     * @param array $array2
+     * @return array
+     * @author Daniel <daniel (at) danielsmedegaardbuus (dot) dk>
+     * @author Gabriel Sobrinho <gabriel (dot) sobrinho (at) gmail (dot) com>
+     * @author Stefan Melbinger <stefan (dot) melbinger (at) gmail (dot) com>
+     * @see http://php.net/manual/en/function.array-merge-recursive.php
+    */
+    private function array_merge_recursive_distinct(array $array1, array $array2)
+    {
+        $merged = $array1;
+    
+        foreach ($array2 as $key => $value) {
+            if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
+                $merged[$key] = $this->array_merge_recursive_distinct($merged[$key], $value);
+            } else {
+                $merged[$key] = $value;
+            }
+        }
+
+        return $merged;
     }
 }

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -297,14 +297,14 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
     public function mergeRecursiveDistinct($key, $value = null)
     {
         if (is_array($key)) {
-            $this->items = $this->array_merge_recursive_distinct($this->items, $key);
+            $this->items = $this->arrayMergeRecursiveDistinct($this->items, $key);
         } elseif (is_string($key)) {
             $items = (array) $this->get($key);
-            $value = $this->array_merge_recursive_distinct($items, $this->getArrayItems($value));
+            $value = $this->arrayMergeRecursiveDistinct($items, $this->getArrayItems($value));
 
             $this->set($key, $value);
         } elseif ($key instanceof self) {
-            $this->items = $this->array_merge_recursive_distinct($this->items, $key->all());
+            $this->items = $this->arrayMergeRecursiveDistinct($this->items, $key->all());
         }
     }
 
@@ -544,13 +544,13 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      * @author Stefan Melbinger <stefan (dot) melbinger (at) gmail (dot) com>
      * @see http://php.net/manual/en/function.array-merge-recursive.php
     */
-    private function array_merge_recursive_distinct(array $array1, array $array2)
+    private function arrayMergeRecursiveDistinct(array $array1, array $array2)
     {
         $merged = $array1;
     
         foreach ($array2 as $key => $value) {
             if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
-                $merged[$key] = $this->array_merge_recursive_distinct($merged[$key], $value);
+                $merged[$key] = $this->arrayMergeRecursiveDistinct($merged[$key], $value);
             } else {
                 $merged[$key] = $value;
             }

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -313,6 +313,122 @@ class DotTest extends TestCase
 
     /*
      * --------------------------------------------------------------
+     * Recursive merge
+     * --------------------------------------------------------------
+     */
+
+    public function testRecursiveMergeArrayWithDot()
+    {
+        $dot = new Dot(['foo' => ['bar' => 'baz']]);
+        $dot->mergeRecursive(['foo' => ['bar' => 'qux']]);
+        $this->assertEquals(['baz', 'qux'], $dot->get('foo.bar'));
+
+        $deep_dot = new Dot(['foo' => ['mel' => ['bar' => 'baz']]]);
+        $deep_dot->mergeRecursive(['foo' => ['mel' => ['bar' => 'qux', 'moo' => 'meh']]]);
+        $this->assertEquals(['baz', 'qux'], $deep_dot->get('foo.mel.bar'));
+        $this->assertEquals('meh', $deep_dot->get('foo.mel.moo'));
+    }
+
+    public function testRecursiveMergeArrayWithKey()
+    {
+        $dot = new Dot(['foo' => ['bar' => 'baz']]);
+        $dot->mergeRecursive('foo', ['bar' => 'qux']);
+        $this->assertEquals(['baz', 'qux'], $dot->get('foo.bar'));
+
+        $deep_dot = new Dot(['foo' => ['mel' => ['bar' => 'baz']]]);
+        $deep_dot->mergeRecursive('foo', ['mel' => ['bar' => 'qux', 'moo' => 'meh']]);
+        $this->assertEquals(['baz', 'qux'], $deep_dot->get('foo.mel.bar'));
+        $this->assertEquals('meh', $deep_dot->get('foo.mel.moo'));
+    }
+
+    public function testRecursiveMergeDotWithDot()
+    {
+        $dot1 = new Dot(['foo' => ['bar' => 'baz']]);
+        $dot2 = new Dot(['foo' => ['bar' => 'qux']]);
+        $dot1->mergeRecursive($dot2);
+        $this->assertEquals(['baz', 'qux'], $dot1->get('foo.bar'));
+
+        $deep_dot1 = new Dot(['foo' => ['mel' => ['bar' => 'baz']]]);
+        $deep_dot2 = new Dot(['foo' => ['mel' => ['bar' => 'qux', 'moo' => 'meh']]]);
+        $deep_dot1->mergeRecursive($deep_dot2);
+        $this->assertEquals(['baz', 'qux'], $deep_dot1->get('foo.mel.bar'));
+        $this->assertEquals('meh', $deep_dot1->get('foo.mel.moo'));
+    }
+
+    public function testRecursiveMergeDotObjectWithKey()
+    {
+        $dot1 = new Dot(['foo' => ['bar' => 'baz']]);
+        $dot2 = new Dot(['bar' => 'qux']);
+        $dot1->mergeRecursive('foo', $dot2);
+        $this->assertEquals(['baz', 'qux'], $dot1->get('foo.bar'));
+
+        $deep_dot1 = new Dot(['foo' => ['mel' => ['bar' => 'baz']]]);
+        $deep_dot2 = new Dot(['mel' => ['bar' => 'qux', 'moo' => 'meh']]);
+        $deep_dot1->mergeRecursive('foo', $deep_dot2);
+        $this->assertEquals(['baz', 'qux'], $deep_dot1->get('foo.mel.bar'));
+        $this->assertEquals('meh', $deep_dot1->get('foo.mel.moo'));
+    }
+
+    /*
+     * --------------------------------------------------------------
+     * Recursive distinct merge
+     * --------------------------------------------------------------
+     */
+
+    public function testRecursiveDistinctMergeArrayWithDot()
+    {
+        $dot = new Dot(['foo' => ['bar' => 'baz']]);
+        $dot->mergeRecursiveDistinct(['foo' => ['bar' => 'qux']]);
+        $this->assertEquals('qux', $dot->get('foo.bar'));
+
+        $deep_dot = new Dot(['foo' => ['mel' => ['bar' => 'baz']]]);
+        $deep_dot->mergeRecursiveDistinct(['foo' => ['mel' => ['bar' => 'qux', 'moo' => 'meh']]]);
+        $this->assertEquals('qux', $deep_dot->get('foo.mel.bar'));
+        $this->assertEquals('meh', $deep_dot->get('foo.mel.moo'));
+    }
+
+    public function testRecursiveDistinctMergeArrayWithKey()
+    {
+        $dot = new Dot(['foo' => ['bar' => 'baz']]);
+        $dot->mergeRecursiveDistinct('foo', ['bar' => 'qux']);
+        $this->assertEquals('qux', $dot->get('foo.bar'));
+
+        $deep_dot = new Dot(['foo' => ['mel' => ['bar' => 'baz']]]);
+        $deep_dot->mergeRecursiveDistinct('foo', ['mel' => ['bar' => 'qux', 'moo' => 'meh']]);
+        $this->assertEquals('qux', $deep_dot->get('foo.mel.bar'));
+        $this->assertEquals('meh', $deep_dot->get('foo.mel.moo'));
+    }
+
+    public function testRecursiveDistinctMergeDotWithDot()
+    {
+        $dot1 = new Dot(['foo' => ['bar' => 'baz']]);
+        $dot2 = new Dot(['foo' => ['bar' => 'qux']]);
+        $dot1->mergeRecursiveDistinct($dot2);
+        $this->assertEquals('qux', $dot1->get('foo.bar'));
+
+        $deep_dot1 = new Dot(['foo' => ['mel' => ['bar' => 'baz']]]);
+        $deep_dot2 = new Dot(['foo' => ['mel' => ['bar' => 'qux', 'moo' => 'meh']]]);
+        $deep_dot1->mergeRecursiveDistinct($deep_dot2);
+        $this->assertEquals('qux', $deep_dot1->get('foo.mel.bar'));
+        $this->assertEquals('meh', $deep_dot1->get('foo.mel.moo'));
+    }
+
+    public function testRecursiveDistinctMergeDotObjectWithKey()
+    {
+        $dot1 = new Dot(['foo' => ['bar' => 'baz']]);
+        $dot2 = new Dot(['bar' => 'qux']);
+        $dot1->mergeRecursiveDistinct('foo', $dot2);
+        $this->assertEquals('qux', $dot1->get('foo.bar'));
+
+        $deep_dot1 = new Dot(['foo' => ['mel' => ['bar' => 'baz']]]);
+        $deep_dot2 = new Dot(['mel' => ['bar' => 'qux', 'moo' => 'meh']]);
+        $deep_dot1->mergeRecursiveDistinct('foo', $deep_dot2);
+        $this->assertEquals('qux', $deep_dot1->get('foo.mel.bar'));
+        $this->assertEquals('meh', $deep_dot1->get('foo.mel.moo'));
+    }
+
+    /*
+     * --------------------------------------------------------------
      * Pull
      * --------------------------------------------------------------
      */


### PR DESCRIPTION
While `Dot::merge()` resembles PHP's `array_merge()`, there is currently no equivalent for `array_merge_recursive()`. This PR implements `Dot::mergeRecursive()` for this reason.

Also, PHP is missing a way to recursively merge arrays and overwrite values for duplicate keys (see [php.net](http://php.net/manual/en/function.array-merge-recursive.php#92195)). `Dot::mergeRecursiveDistinct()` implements this functionality.