### PR TITLE
Add flatten method (including tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Dot has the following methods:
 
 - [add()](#add)
 - [all()](#all)
+- [flatten()](#flatten)
 - [clear()](#clear)
 - [count()](#count)
 - [delete()](#delete)
@@ -111,6 +112,13 @@ $dot->add([
 Returns all the stored items as an array:
 ```php
 $values = $dot->all();
+```
+
+### flatten()
+
+Returns an flatten array with the keys delimited by a givin character (by default: .)
+```php
+$flatten = $dot->flatten();
 ```
 
 <a name="clear"></a>

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -373,6 +373,33 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
         return json_encode($this->items, $options);
     }
 
+    /**
+     * Return a flatten array with a given character as key delimiter.
+     *
+     * @param string $char
+     * @return array
+     */
+    public function flatten($char = '.', $items = null, $parentKeys = [])
+    {
+        $flatten = [];
+
+        if (is_null($items)) {
+            $items = $this->items;
+        }
+
+        foreach ($items as $key => $value) {
+            $currentKey = array_merge($parentKeys, [$key]);
+
+            if (is_array($value)) {
+                $flatten += $this->flatten($char, $value, $currentKey);
+            } else {
+                $flatten[implode($char, $currentKey)] = $value;
+            }
+        }
+
+        return $flatten;
+    }
+
     /*
      * --------------------------------------------------------------
      * ArrayAccess interface

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -471,6 +471,29 @@ class DotTest extends TestCase
 
     /*
      * --------------------------------------------------------------
+     * Flatten
+     * --------------------------------------------------------------
+     */
+    public function testFlatten()
+    {
+        $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]]);
+        $flatten = $dot->flatten();
+
+        $this->assertEquals('xyz', $flatten['foo.abc']);
+        $this->assertEquals('baz', $flatten['foo.bar.0']);
+    }
+
+    public function testFlattenWithCustomCharacter()
+    {
+        $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]]);
+        $flatten = $dot->flatten('_');
+
+        $this->assertEquals('xyz', $flatten['foo_abc']);
+        $this->assertEquals('baz', $flatten['foo_bar_0']);
+    }
+
+    /*
+     * --------------------------------------------------------------
      * To JSON
      * --------------------------------------------------------------
      */


### PR DESCRIPTION
I added a method which returns a flatten (single dimension) array with all keys delimited by a given method. Tests provided.

The difference with the get() method and ArrayAccess is that you don't have to know the structure of the array.