### PR TITLE
Add method Dot::flatten() which returns a flattened array

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Dot has the following methods:
 - [clear()](#clear)
 - [count()](#count)
 - [delete()](#delete)
+- [flatten()](#flatten)
 - [get()](#get)
 - [has()](#has)
 - [isEmpty()](#isEmpty)
@@ -173,6 +174,14 @@ $dot->delete([
     'user.name',
     'page.title'
 ]);
+```
+
+<a name="flatten"></a>
+### flatten()
+
+Returns a flattened array with the keys delimited by a given character (default "."):
+```php
+$flatten = $dot->flatten();
 ```
 
 <a name="get"></a>

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -133,6 +133,36 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
+     * Flatten an array with the given character as a key delimiter
+     *
+     * @param  string     $delimiter
+     * @param  array|null $items
+     * @param  string     $prepend
+     * @return array
+     */
+    public function flatten($delimiter = '.', $items = null, $prepend = '')
+    {
+        $flatten = [];
+
+        if (is_null($items)) {
+            $items = $this->items;
+        }
+
+        foreach ($items as $key => $value) {
+            if (is_array($value) && !empty($value)) {
+                $flatten = array_merge(
+                    $flatten,
+                    $this->flatten($delimiter, $value, $prepend.$key.$delimiter)
+                );
+            } else {
+                $flatten[$prepend.$key] = $value;
+            }
+        }
+
+        return $flatten;
+    }
+
+    /**
      * Return the value of a given key
      *
      * @param  int|string|null $key

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -172,6 +172,27 @@ class DotTest extends TestCase
 
     /*
      * --------------------------------------------------------------
+     * Flatten
+     * --------------------------------------------------------------
+     */
+    public function testFlatten()
+    {
+        $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]]);
+        $flatten = $dot->flatten();
+        $this->assertEquals('xyz', $flatten['foo.abc']);
+        $this->assertEquals('baz', $flatten['foo.bar.0']);
+    }
+    
+    public function testFlattenWithCustomDelimiter()
+    {
+        $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]]);
+        $flatten = $dot->flatten('_');
+        $this->assertEquals('xyz', $flatten['foo_abc']);
+        $this->assertEquals('baz', $flatten['foo_bar_0']);
+    }
+
+    /*
+     * --------------------------------------------------------------
      * Get
      * --------------------------------------------------------------
      */


### PR DESCRIPTION
Referring to https://github.com/adbario/php-dot-notation/pull/4 I was make changes as @adbario say. 
Thanks to @svencoeck for original pull request