### PR TITLE
Added ability to auto parsing flatten arrays while constructing new Dot object

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ $dot = new \Adbar\Dot;
 
 // With existing array
 $dot = new \Adbar\Dot($array);
+
+// Or with auto parsing dot notation keys in existing array
+$dot = new \Adbar\Dot($array, true);
 ```
 
 You can also use a helper function to create the object:
@@ -62,6 +65,9 @@ $dot = dot();
 
 // With existing array
 $dot = dot($array);
+
+// Or with auto parsing dot notation keys in existing array
+$dot = dot($array, true);
 ```
 
 ## Methods

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -33,10 +33,17 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      * Create a new Dot instance
      *
      * @param mixed $items
+     * @param bool  $parse
      */
-    public function __construct($items = [])
+    public function __construct($items = [], $parse = false)
     {
-        $this->items = $this->getArrayItems($items);
+        $items = $this->getArrayItems($items);
+        if ($parse === true) {
+            $this->set($items);
+            return;
+        }
+
+        $this->items = $items;
     }
 
     /**
@@ -206,7 +213,9 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
     {
         if (is_array($items)) {
             return $items;
-        } elseif ($items instanceof self) {
+        }
+
+        if ($items instanceof self) {
             return $items->all();
         }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,10 +14,11 @@ if (! function_exists('dot')) {
      * Create a new Dot object with the given items
      *
      * @param  mixed $items
+     * @param  bool  $parse
      * @return \Adbar\Dot
      */
-    function dot($items)
+    function dot($items, $parse = false)
     {
-        return new Dot($items);
+        return new Dot($items, $parse);
     }
 }

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -56,6 +56,14 @@ class DotTest extends TestCase
         $this->assertEquals('bar', $dot->get('foo'));
     }
 
+    public function testConstructWithParsing()
+    {
+        $dot = new Dot(['foo.bar' => 'baz']);
+        $this->assertEquals(['foo.bar' => 'baz'], $dot->get());
+        $dot = new Dot(['foo.bar' => 'baz'], true);
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $dot->get());
+    }
+
     /*
      * --------------------------------------------------------------
      * Add
@@ -182,7 +190,7 @@ class DotTest extends TestCase
         $this->assertEquals('xyz', $flatten['foo.abc']);
         $this->assertEquals('baz', $flatten['foo.bar.0']);
     }
-    
+
     public function testFlattenWithCustomDelimiter()
     {
         $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]]);


### PR DESCRIPTION
Just idea for little improvement: *fromFlatten* construction.

Old behavior:
```
var_dump(dot([
    'id' => 1,
    'nested.field' => 'value'
])->toJson()); // string(31) "{"id":1,"nested.field":"value"}"
```

New behavior allows auto parsing dot notation keys from initial array.

Next snippets are equals.
- without auto parsing
```
$dot = dot([]);
$dot->set([
    'id' => 1,
    'nested.field' => 'value'
]);
var_dump($dot->toJson()); // string(35) "{"id":1,"nested":{"field":"value"}}"
```
- with auto parsing
```
var_dump(dot([
    'id' => 1,
    'nested.field' => 'value'
], true)->toJson()); // string(35) "{"id":1,"nested":{"field":"value"}}"
```