### PR TITLE
Allowed asterisk for aggregation

### DIFF
--- a/src/Dot.php
+++ b/src/Dot.php
@@ -445,8 +445,14 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
         }
 
         $items = &$this->items;
+        $append = false;
 
         foreach (explode('.', $keys) as $key) {
+            if ($key === '*') {
+                $append = true;
+                continue;
+            }
+            $append = false;
             if (!isset($items[$key]) || !is_array($items[$key])) {
                 $items[$key] = [];
             }
@@ -454,7 +460,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
             $items = &$items[$key];
         }
 
-        $items = $value;
+        $append ? $items[] = $value : $items = $value;
     }
 
     /**

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -182,7 +182,7 @@ class DotTest extends TestCase
         $this->assertEquals('xyz', $flatten['foo.abc']);
         $this->assertEquals('baz', $flatten['foo.bar.0']);
     }
-    
+
     public function testFlattenWithCustomDelimiter()
     {
         $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]]);
@@ -552,6 +552,29 @@ class DotTest extends TestCase
         $dot->setArray(['foo' => 'bar']);
 
         $this->assertSame(['foo' => 'bar'], $dot->all());
+    }
+
+    /*
+     * --------------------------------------------------------------
+     * Set asterisk
+     * --------------------------------------------------------------
+     */
+
+    public function testSetAsterisk()
+    {
+        $dot = new Dot;
+        $dot->set([
+            'foo' => 'bar',
+            'arr.*' => 'baz',
+        ]);
+
+        $dot->set([
+            'arr.*' => 'fizz',
+        ]);
+
+        $this->assertSame(['baz', 'fizz'], $dot->get('arr'));
+        $this->assertSame('baz', $dot->get('arr.0'));
+        $this->assertSame('fizz', $dot->get('arr.1'));
     }
 
     /*


### PR DESCRIPTION
Just idea for improvement

Allowed to use array aggregation.
Example of usage:
```
$book = [
    'id' => 1,
    'name' => 'Book name',
    'authors.*' => [
        [
            'id' => 1,
            'email' => 'author@email.dot',
        ],
    ],
];
$dot = dot([]);
$dot->set($book);
$dot->set('authors.*', [
    'id' => 2,
    'email' => 'another@email.dot',
]);
count($dot->get('authors')) === 2; // because two authors
```