### PR TITLE
fix: added option to rebase non-associative arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ count($dot);
 <a name="delete"></a>
 ### delete()
 
-Deletes the given key:
+Deletes the given key. `$rebase` is optional argument. It's used to rebase non-associative arrays:
 ```php
-$dot->delete('user.name');
+$dot->delete('user.name', $rebase);
 
 // ArrayAccess
 unset($dot['user.name']);


### PR DESCRIPTION
I think it's quite handy to have the possibility to rebase the non-associative arrays when deleting an element.