### PR TITLE
Custom delimiter for the instance

### DIFF
--- a/src/Dot.php
+++ b/src/Dot.php
@@ -31,12 +31,21 @@ use Traversable;
  */
 class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
 {
+    public const DEFAULT_DELIMITER = '.';
+
     /**
      * The stored items
      *
      * @var array<TKey, TValue>
      */
     protected $items = [];
+
+    /**
+     * The delimiter for instance
+     *
+     * @var null|string
+     */
+    protected $delimiter;
 
     /**
      * Create a new Dot instance
@@ -54,6 +63,33 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
         } else {
             $this->items = $items;
         }
+    }
+
+    /**
+     * Set delimiter for the instance
+     *
+     * @param null|string $delimiter
+     * @return $this
+     */
+    public function setDelimiter($delimiter = null)
+    {
+        $this->delimiter = $delimiter ?: null;
+
+        return $this;
+    }
+
+    /**
+     * Get delimiter for the instance
+     *
+     * @return non-empty-string
+     */
+    public function getDelimiter()
+    {
+        if (strlen($this->delimiter)) {
+            return $this->delimiter;
+        }
+
+        return self::DEFAULT_DELIMITER;
     }
 
     /**
@@ -128,7 +164,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
             }
 
             $items = &$this->items;
-            $segments = explode('.', $key);
+            $segments = explode($this->getDelimiter(), $key);
             $lastSegment = array_pop($segments);
 
             foreach ($segments as $segment) {
@@ -165,8 +201,10 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      * @param  string  $prepend
      * @return array<TKey, TValue>
      */
-    public function flatten($delimiter = '.', $items = null, $prepend = '')
+    public function flatten($delimiter = null, $items = null, $prepend = '')
     {
+        $delimiter = $delimiter ?? $this->getDelimiter();
+
         $flatten = [];
 
         if ($items === null) {
@@ -201,13 +239,13 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
             return $this->items[$key];
         }
 
-        if (!is_string($key) || strpos($key, '.') === false) {
+        if (!is_string($key) || strpos($key, $this->getDelimiter()) === false) {
             return $default;
         }
 
         $items = $this->items;
 
-        foreach (explode('.', $key) as $segment) {
+        foreach (explode($this->getDelimiter(), $key) as $segment) {
             if (!is_array($items) || !$this->exists($items, $segment)) {
                 return $default;
             }
@@ -258,7 +296,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
                 continue;
             }
 
-            foreach (explode('.', $key) as $segment) {
+            foreach (explode($this->getDelimiter(), $key) as $segment) {
                 if (!is_array($items) || !$this->exists($items, $segment)) {
                     return false;
                 }
@@ -487,7 +525,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
         $items = &$this->items;
 
         if (is_string($keys)) {
-            foreach (explode('.', $keys) as $key) {
+            foreach (explode($this->getDelimiter(), $keys) as $key) {
                 if (!isset($items[$key]) || !is_array($items[$key])) {
                     $items[$key] = [];
                 }

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -541,7 +541,7 @@ class DotTest extends TestCase
 
     public function testPushReturnsDot(): void
     {
-        $dot = $dot = new Dot();
+        $dot = new Dot();
 
         $this->assertInstanceOf(Dot::class, $dot->push('foo'));
     }
@@ -669,6 +669,49 @@ class DotTest extends TestCase
 
     /*
      * --------------------------------------------------------------
+     * Operations with custom delimiter
+     * --------------------------------------------------------------
+     */
+
+    public function testSetOrUnsetCustomDelimiter(): void
+    {
+        $dot = new Dot();
+        $this->assertEquals('.', $dot->getDelimiter());
+        $dot->setDelimiter('|');
+        $this->assertEquals('|', $dot->getDelimiter());
+        $dot->setDelimiter();
+        $this->assertEquals('.', $dot->getDelimiter());
+    }
+
+    public function testSetKeyValueWithCustomDelimiter(): void
+    {
+        $dot = new Dot();
+        $dot->setDelimiter('|');
+        $dot->set('foo|bar', 'baz');
+
+        $this->assertEquals('baz', $dot->get('foo|bar'));
+    }
+
+    public function testSetKeyValuePairWithCustomDelimiter(): void
+    {
+        $dot = new Dot();
+        $dot->setDelimiter('|');
+        $dot->set('foo|bar', 'baz');
+
+        $this->assertEquals('baz', $dot->get('foo|bar'));
+    }
+
+    public function testFlattenForCustomDelimiter(): void
+    {
+        $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]]);
+        $dot->setDelimiter('|');
+        $flatten = $dot->flatten('_');
+        $this->assertEquals('xyz', $flatten['foo_abc']);
+        $this->assertEquals('baz', $flatten['foo_bar_0']);
+    }
+
+    /*
+     * --------------------------------------------------------------
      * ArrayAccess interface
      * --------------------------------------------------------------
      */
@@ -788,6 +831,7 @@ class DotTest extends TestCase
             "      'bar' => 'baz',\n" .
             "    ),\n" .
             "  ),\n" .
+            "   'delimiter' => NULL,\n" .
             "))",
             var_export($dot, true)
         );


### PR DESCRIPTION
Just idea :)

We can change delimiter for Dot instance

```
$dot->setDelimiter('|');
```

and then any operations will works with new notation, example:

```
$dot->set('foo|bar', 'baz');
// or
$dot->get('foo|bar');
```

If we need to clear custom delimiter, just set **null**

> default delimiter is dot as usual :)