### PR TITLE
[2.x] Suppress PHP 8 deprecation notice for Iterator implementation methods

### DIFF
--- a/src/Dot.php
+++ b/src/Dot.php
@@ -507,6 +507,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      * @param  int|string $key
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return $this->has($key);
@@ -518,6 +519,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      * @param  int|string $key
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key);
@@ -529,6 +531,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      * @param int|string|null $key
      * @param mixed           $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         if (is_null($key)) {
@@ -545,6 +548,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      *
      * @param int|string $key
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         $this->delete($key);
@@ -562,6 +566,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      * @param  int|string|null $key
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count($key = null)
     {
         return count($this->get($key));
@@ -578,6 +583,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      *
      * @return \ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->items);


### PR DESCRIPTION
I am using PHP 8.1 and there is a third-party library that depends on `php-dot-notation` 2.x, my PHP logs have too many these notices 😭 
If there are no other issues, Please merge this PR and publish a new version for 2.x, thanks a lot 👍 

> PHP Deprecated:  Return type of Adbar\Dot::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/elfsundae/data/projects/php/aliyun-tea-php/vendor/adbario/php-dot-notation/src/Dot.php on line 510
> PHP Deprecated:  Return type of Adbar\Dot::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/elfsundae/data/projects/php/aliyun-tea-php/vendor/adbario/php-dot-notation/src/Dot.php on line 521
> PHP Deprecated:  Return type of Adbar\Dot::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/elfsundae/data/projects/php/aliyun-tea-php/vendor/adbario/php-dot-notation/src/Dot.php on line 532
> PHP Deprecated:  Return type of Adbar\Dot::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/elfsundae/data/projects/php/aliyun-tea-php/vendor/adbario/php-dot-notation/src/Dot.php on line 548
