### PR TITLE
Add PHP attrib to suppress return type deprecation

### DIFF
--- a/src/Dot.php
+++ b/src/Dot.php
@@ -600,6 +600,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->items;


### PR DESCRIPTION
This updates `Dot::jsonSerialize()` so that the deprecation warnings for PHP 8.1 are truly suppressed.