### PR TITLE
Adding per collection custom delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ $dot = dot();
 $dot = dot($array);
 ```
 
+It is possible use an alternative delimiter from the default dot (`.`) with the second constructor parameter.  Using an underscore instead:
+
+```php
+$dot = new \Adbar\Dot($array, '_');
+
+// With the helper
+$dot = dot($array, '_');
+```
+
 ## Methods
 
 Dot has the following methods:

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -47,7 +47,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
     public function __construct($items = [], $delimiter = '.')
     {
         $this->items = $this->getArrayItems($items);
-        $this->delimiter = $delimiter;
+        $this->delimiter = strlen($delimiter) ? $delimiter : '.';
     }
 
     /**

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -29,14 +29,25 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      */
     protected $items = [];
 
+
+    /**
+     * The delimiter (alternative to a '.') to be used.
+     *
+     * @var string
+     */
+    protected $delimiter = '.';
+
+
     /**
      * Create a new Dot instance
      *
      * @param mixed $items
+     * @param string $delimiter
      */
-    public function __construct($items = [])
+    public function __construct($items = [], $delimiter = '.')
     {
         $this->items = $this->getArrayItems($items);
+        $this->delimiter = $delimiter;
     }
 
     /**
@@ -104,7 +115,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
             }
 
             $items = &$this->items;
-            $segments = explode('.', $key);
+            $segments = explode($this->delimiter, $key);
             $lastSegment = array_pop($segments);
 
             foreach ($segments as $segment) {
@@ -148,6 +159,10 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
             $items = $this->items;
         }
 
+        if (!func_num_args()) {
+            $delimiter = $this->delimiter;
+        }
+
         foreach ($items as $key => $value) {
             if (is_array($value) && !empty($value)) {
                 $flatten = array_merge(
@@ -179,13 +194,13 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
             return $this->items[$key];
         }
 
-        if (strpos($key, '.') === false) {
+        if (strpos($key, $this->delimiter) === false) {
             return $default;
         }
 
         $items = $this->items;
 
-        foreach (explode('.', $key) as $segment) {
+        foreach (explode($this->delimiter, $key) as $segment) {
             if (!is_array($items) || !$this->exists($items, $segment)) {
                 return $default;
             }
@@ -234,7 +249,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
                 continue;
             }
 
-            foreach (explode('.', $key) as $segment) {
+            foreach (explode($this->delimiter, $key) as $segment) {
                 if (!is_array($items) || !$this->exists($items, $segment)) {
                     return false;
                 }
@@ -446,7 +461,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
 
         $items = &$this->items;
 
-        foreach (explode('.', $keys) as $key) {
+        foreach (explode($this->delimiter, $keys) as $key) {
             if (!isset($items[$key]) || !is_array($items[$key])) {
                 $items[$key] = [];
             }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,13 +11,14 @@ use Adbar\Dot;
 
 if (! function_exists('dot')) {
     /**
-     * Create a new Dot object with the given items
+     * Create a new Dot object with the given items and optional delimiter
      *
-     * @param  mixed $items
+     * @param  mixed  $items
+     * @param  string $delimiter
      * @return \Adbar\Dot
      */
-    function dot($items)
+    function dot($items, $delimiter = '.')
     {
-        return new Dot($items);
+        return new Dot($items, $delimiter);
     }
 }

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -70,6 +70,14 @@ class DotTest extends TestCase
         $this->assertEquals('baz', $dot->get('foo.bar'));
     }
 
+    public function testAddKeyValuePairWithCustomDelimeter()
+    {
+        $dot = new Dot([], '/');
+        $dot->add('foo/bar', 'baz');
+
+        $this->assertEquals('baz', $dot->get('foo/bar'));
+    }
+
     public function testAddValueToExistingKey()
     {
         $dot = new Dot(['foo' => 'bar']);
@@ -116,6 +124,14 @@ class DotTest extends TestCase
         $this->assertSame([], $dot->get('foo.bar'));
     }
 
+    public function testClearKeyWithCustomDelimiter()
+    {
+        $dot = new Dot(['foo' => ['bar' => 'baz']], '/');
+        $dot->clear('foo/bar');
+
+        $this->assertSame([], $dot->get('foo/bar'));
+    }
+
     public function testClearNonExistingKey()
     {
         $dot = new Dot;
@@ -154,6 +170,14 @@ class DotTest extends TestCase
         $this->assertFalse($dot->has('foo.bar'));
     }
 
+    public function testDeleteKeyWithCustomDelimeter()
+    {
+        $dot = new Dot(['foo' => ['bar' => 'baz']], '/');
+        $dot->delete('foo/bar');
+
+        $this->assertFalse($dot->has('foo/bar'));
+    }
+
     public function testDeleteNonExistingKey()
     {
         $dot = new Dot(['foo' => 'bar']);
@@ -182,14 +206,24 @@ class DotTest extends TestCase
         $this->assertEquals('xyz', $flatten['foo.abc']);
         $this->assertEquals('baz', $flatten['foo.bar.0']);
     }
-    
+
     public function testFlattenWithCustomDelimiter()
     {
-        $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]]);
+        $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]], '/');
+        $flatten = $dot->flatten();
+        $this->assertEquals('xyz', $flatten['foo/abc']);
+        $this->assertEquals('baz', $flatten['foo/bar/0']);
+    }
+
+
+    public function testFlattenWithDoubleCustomDelimiter()
+    {
+        $dot = new Dot(['foo' => ['abc' => 'xyz', 'bar' => ['baz']]], '/');
         $flatten = $dot->flatten('_');
         $this->assertEquals('xyz', $flatten['foo_abc']);
         $this->assertEquals('baz', $flatten['foo_bar_0']);
     }
+
 
     /*
      * --------------------------------------------------------------
@@ -531,6 +565,15 @@ class DotTest extends TestCase
 
         $this->assertEquals('baz', $dot->get('foo.bar'));
     }
+
+    public function testSetKeyValuePairWithCustomDelimiter()
+    {
+        $dot = new Dot([], '/');
+        $dot->set('foo/bar', 'baz');
+
+        $this->assertEquals('baz', $dot->get('foo/bar'));
+    }
+
 
     public function testSetArrayOfKeyValuePairs()
     {


### PR DESCRIPTION
This is a pull request for 2.x (for a v2.5) to add the custom delimiter at the constructor (per collection) level only per #35.