### PR TITLE
Implement optional custom delimeter

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright (c) 2016-2019 Riku Särkinen
+Copyright (c) 2016-2022 Riku Särkinen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ $dot = new \Adbar\Dot($array);
 
 // Or with auto parsing dot notation keys in existing array
 $dot = new \Adbar\Dot($array, true);
+
+// You can also set a custom delimiter instead of the default dot (.)
+$dot = new \Adbar\Dot($array, false, "_");
 ```
 
 You can also use a helper function to create the object:
@@ -73,6 +76,9 @@ $dot = dot($array);
 
 // Or with auto parsing dot notation keys in existing array
 $dot = dot($array, true);
+
+// You can also set a custom delimiter instead of the default dot (.)
+$dot = dot($array, true, "_");
 ```
 
 All methods not returning a specific value returns the Dot object for chaining:

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -5,7 +5,7 @@
  *
  * @author  Riku Särkinen <riku@adbar.io>
  * @link    https://github.com/adbario/php-dot-notation
- * @license https://github.com/adbario/php-dot-notation/blob/2.x/LICENSE.md (MIT License)
+ * @license https://github.com/adbario/php-dot-notation/blob/3.x/LICENSE.md (MIT License)
  */
 
 namespace Adbar;
@@ -36,18 +36,29 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      *
      * @var array<TKey, TValue>
      */
-    protected $items = [];
+    protected $items;
+
+    /**
+     * The character to use as a delimiter, defaults to dot (.)
+     *
+     * @var non-empty-string
+     */
+    protected $delimiter = ".";
 
     /**
      * Create a new Dot instance
      *
      * @param  mixed  $items
      * @param  bool  $parse
+     * @param  non-empty-string  $delimiter
      * @return void
      */
-    public function __construct($items = [], $parse = false)
+    public function __construct($items = [], $parse = false, $delimiter = ".")
     {
         $items = $this->getArrayItems($items);
+
+        // $this->delimiter = strlen($delimiter) ? $delimiter : '.';
+        $this->delimiter = $delimiter ?: ".";
 
         if ($parse) {
             $this->set($items);
@@ -128,7 +139,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
             }
 
             $items = &$this->items;
-            $segments = explode('.', $key);
+            $segments = explode($this->delimiter, $key);
             $lastSegment = array_pop($segments);
 
             foreach ($segments as $segment) {
@@ -201,13 +212,13 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
             return $this->items[$key];
         }
 
-        if (!is_string($key) || strpos($key, '.') === false) {
+        if (!is_string($key) || strpos($key, $this->delimiter) === false) {
             return $default;
         }
 
         $items = $this->items;
 
-        foreach (explode('.', $key) as $segment) {
+        foreach (explode($this->delimiter, $key) as $segment) {
             if (!is_array($items) || !$this->exists($items, $segment)) {
                 return $default;
             }
@@ -258,7 +269,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
                 continue;
             }
 
-            foreach (explode('.', $key) as $segment) {
+            foreach (explode($this->delimiter, $key) as $segment) {
                 if (!is_array($items) || !$this->exists($items, $segment)) {
                     return false;
                 }
@@ -487,7 +498,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
         $items = &$this->items;
 
         if (is_string($keys)) {
-            foreach (explode('.', $keys) as $key) {
+            foreach (explode($this->delimiter, $keys) as $key) {
                 if (!isset($items[$key]) || !is_array($items[$key])) {
                     $items[$key] = [];
                 }

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -57,7 +57,6 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
     {
         $items = $this->getArrayItems($items);
 
-        // $this->delimiter = strlen($delimiter) ? $delimiter : '.';
         $this->delimiter = $delimiter ?: ".";
 
         if ($parse) {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,7 +5,7 @@
  *
  * @author  Riku Särkinen <riku@adbar.io>
  * @link    https://github.com/adbario/php-dot-notation
- * @license https://github.com/adbario/php-dot-notation/blob/2.x/LICENSE.md (MIT License)
+ * @license https://github.com/adbario/php-dot-notation/blob/3.x/LICENSE.md (MIT License)
  */
 
 use Adbar\Dot;
@@ -16,10 +16,11 @@ if (! function_exists('dot')) {
      *
      * @param  mixed  $items
      * @param  bool  $parse
+     * @param  non-empty-string  $delimiter
      * @return \Adbar\Dot<array-key, mixed>
      */
-    function dot($items, $parse = false)
+    function dot($items, $parse = false, $delimiter = ".")
     {
-        return new Dot($items, $parse);
+        return new Dot($items, $parse, $delimiter);
     }
 }

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -5,7 +5,7 @@
  *
  * @author  Riku Särkinen <riku@adbar.io>
  * @link    https://github.com/adbario/php-dot-notation
- * @license https://github.com/adbario/php-dot-notation/blob/2.x/LICENSE.md (MIT License)
+ * @license https://github.com/adbario/php-dot-notation/blob/3.x/LICENSE.md (MIT License)
  */
 
 namespace Adbar\Tests;
@@ -50,6 +50,28 @@ class DotTest extends TestCase
         $this->assertEquals('bar', $dot2->get('foo'));
     }
 
+    public function testConstructWithParsing(): void
+    {
+        $dot = new Dot(['foo.bar' => 'baz']);
+
+        $this->assertEquals(['foo.bar' => 'baz'], $dot->get());
+
+        $dot = new Dot(['foo.bar' => 'baz'], true);
+
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $dot->get());
+    }
+
+    public function testConstructWithCustomDelimiter(): void
+    {
+        $dot = new Dot(['foo_bar' => 'baz'], false, "_");
+
+        $this->assertEquals(['foo_bar' => 'baz'], $dot->get());
+
+        $dot = new Dot(['foo_bar' => 'baz'], true, "_");
+
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $dot->get());
+    }
+
     public function testConstructHelper(): void
     {
         $dot = dot(['foo' => 'bar']);
@@ -58,13 +80,20 @@ class DotTest extends TestCase
         $this->assertEquals('bar', $dot->get('foo'));
     }
 
-    public function testConstructWithParsing(): void
+    public function testConstructHelpertWithParsing(): void
     {
-        $dot = new Dot(['foo.bar' => 'baz']);
+        $dot = dot(['foo.bar' => 'baz'], true);
 
-        $this->assertEquals(['foo.bar' => 'baz'], $dot->get());
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $dot->get());
+    }
 
-        $dot = new Dot(['foo.bar' => 'baz'], true);
+    public function testConstructHelpertWithCustomDelimiter(): void
+    {
+        $dot = dot(['foo_bar' => 'baz'], false, "_");
+
+        $this->assertEquals(['foo_bar' => 'baz'], $dot->get());
+
+        $dot = dot(['foo_bar' => 'baz'], true, "_");
 
         $this->assertEquals(['foo' => ['bar' => 'baz']], $dot->get());
     }
@@ -788,6 +817,7 @@ class DotTest extends TestCase
             "      'bar' => 'baz',\n" .
             "    ),\n" .
             "  ),\n" .
+            "   'delimiter' => '.',\n" .
             "))",
             var_export($dot, true)
         );


### PR DESCRIPTION
Adds an option to set a custom delimiter instead of the default dot (.) when creating a new Dot object.