### PR TITLE
Fix parsing empty constructor array

### DIFF
--- a/src/Dot.php
+++ b/src/Dot.php
@@ -36,7 +36,7 @@ class Dot implements ArrayAccess, Countable, IteratorAggregate, JsonSerializable
      *
      * @var array<TKey, TValue>
      */
-    protected $items;
+    protected $items = [];
 
     /**
      * The character to use as a delimiter, defaults to dot (.)

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -59,6 +59,10 @@ class DotTest extends TestCase
         $dot = new Dot(['foo.bar' => 'baz'], true);
 
         $this->assertEquals(['foo' => ['bar' => 'baz']], $dot->get());
+
+        $dot = new Dot([], true);
+
+        $this->assertEquals([], $dot->get());
     }
 
     public function testConstructWithCustomDelimiter(): void


### PR DESCRIPTION
Fixes https://github.com/adbario/php-dot-notation/issues/40

When passing an empty array and parsing it, items should return an empty array instead of null